### PR TITLE
change theme from catppuccin -> adwaita

### DIFF
--- a/homeManagerModules/apps/chromium/default.nix
+++ b/homeManagerModules/apps/chromium/default.nix
@@ -14,7 +14,6 @@
         {id = "mnjggcdmjocbbbhaepdhchncahnbgone";} # sponsorblock
         {id = "oboonakemofpalcgghocfoadofidjkkk";} # keepassxc
         {id = "ocabkmapohekeifbkoelpmppmfbcibna";} # zoom redirector
-        {id = "olhelnoplefjdmncknfphenjclimckaf";} # catppuccin frappe
       ];
     };
   };

--- a/homeManagerModules/apps/emacs/default.nix
+++ b/homeManagerModules/apps/emacs/default.nix
@@ -7,9 +7,10 @@
   config = lib.mkIf config.ar.home.apps.emacs.enable {
     programs.emacs = {
       enable = true;
+      extraConfig = builtins.readFile ./emacs.el;
+
       extraPackages = epkgs: (with epkgs; [
         better-defaults
-        catppuccin-theme
         markdown-mode
         nix-mode
         org
@@ -26,8 +27,8 @@
         yaml
         yaml-mode
       ]);
+
       package = pkgs.emacs-nox;
-      extraConfig = builtins.readFile ./emacs.el;
     };
   };
 }

--- a/homeManagerModules/apps/emacs/emacs.el
+++ b/homeManagerModules/apps/emacs/emacs.el
@@ -1,8 +1,3 @@
-; Load catppuccin theme.
-;(load-theme 'catppuccin :no-confirm)
-;(setq catppuccin-flavor 'mocha) ;; or 'latte, 'macchiato, or 'mocha
-;(catppuccin-reload)
-
 ;(defun on-after-init ()
 ;  (unless (display-graphic-p (selected-frame))
 ;    (set-face-background 'default "unspecified-bg" (selected-frame))))

--- a/homeManagerModules/apps/fuzzel/default.nix
+++ b/homeManagerModules/apps/fuzzel/default.nix
@@ -8,6 +8,11 @@
     programs.fuzzel = {
       enable = true;
       settings = {
+        border = {
+          radius = 10;
+          width = 2;
+        };
+
         main = {
           font = "${config.ar.home.theme.terminalFont.name}:size=${toString config.ar.home.theme.terminalFont.size}";
           icon-theme = "${config.ar.home.theme.iconTheme.name}";
@@ -16,16 +21,13 @@
           terminal = lib.getExe config.ar.home.defaultApps.terminal;
           width = 36;
         };
-        border = {
-          radius = 10;
-          width = 2;
-        };
+
         colors = {
           background = "${config.ar.home.theme.colors.background}CC";
           border = "${config.ar.home.theme.colors.primary}EE";
           selection = "${config.ar.home.theme.colors.background}FF";
-          selection-match = "#e78284FF";
-          selection-text = "#f4b8e4FF";
+          selection-match = "${config.ar.home.theme.colors.primary}FF";
+          selection-text = "${config.ar.home.theme.colors.secondary}FF";
           text = "${config.ar.home.theme.colors.text}FF";
         };
       };

--- a/homeManagerModules/apps/neovim/default.nix
+++ b/homeManagerModules/apps/neovim/default.nix
@@ -7,13 +7,7 @@
   config = lib.mkIf config.ar.home.apps.neovim.enable {
     programs.nixvim = {
       enable = true;
-      viAlias = true;
-      vimAlias = true;
-
-      colorschemes.catppuccin = {
-        enable = true;
-        settings.flavor = "frappe";
-      };
+      colorschemes.ayu.enable = true;
 
       plugins = {
         lightline.enable = true;
@@ -22,6 +16,9 @@
         neogit.enable = true;
         nix.enable = true;
       };
+
+      viAlias = true;
+      vimAlias = true;
     };
   };
 }

--- a/homeManagerModules/apps/vsCodium/default.nix
+++ b/homeManagerModules/apps/vsCodium/default.nix
@@ -31,19 +31,14 @@
         "window.zoomPerWindow" = false;
         "workbench.colorTheme" =
           if config.ar.home.theme.colors.preferDark
-          then "Catppuccin Frappé"
-          else "Catppuccin Latte";
-        "workbench.iconTheme" =
-          if config.ar.home.theme.colors.preferDark
-          then "catppuccin-frappe"
-          else "catppuccin-latte";
-        "workbench.preferredDarkColorTheme" = "Catppuccin Frappé";
-        "workbench.preferredLightColorTheme" = "Catppuccin Latte";
+          then "Adwaita Dark"
+          else "Adwaita";
+        "workbench.iconTheme" = "null";
+        "workbench.preferredDarkColorTheme" = "Adwaita Dark";
+        "workbench.preferredLightColorTheme" = "Adwaita";
       };
 
       extensions = with pkgs.vscode-extensions; [
-        catppuccin.catppuccin-vsc
-        catppuccin.catppuccin-vsc-icons
         coolbear.systemd-unit-file
         github.vscode-github-actions
         github.vscode-pull-request-github

--- a/homeManagerModules/apps/vsCodium/default.nix
+++ b/homeManagerModules/apps/vsCodium/default.nix
@@ -52,6 +52,7 @@
         ms-python.python
         ms-vscode.cpptools-extension-pack
         oderwat.indent-rainbow
+        piousdeer.adwaita-theme
         rubymaniac.vscode-paste-and-indent
         rust-lang.rust-analyzer
         tomoki1207.pdf

--- a/homeManagerModules/apps/waybar/default.nix
+++ b/homeManagerModules/apps/waybar/default.nix
@@ -199,7 +199,7 @@
       #mode {
           padding: 0 15px;
           margin: 0 5px;
-          color: #e78284;
+          color: #FFFFFF;
       }
 
       #tags button {
@@ -253,8 +253,8 @@
           border-radius: 10;
           background: rgba ${
         if config.ar.home.theme.colors.preferDark
-        then "(35, 38, 52, 0.8);"
-        else "(220, 224, 232, 0.8);"
+        then "(36, 36, 36, 0.8);"
+        else "(250, 250, 250, 0.8);"
       }
           margin: 5px 10px 0px 10px;
           padding: 0px 10px 0px 10px;
@@ -267,7 +267,7 @@
       #submap,
       #mode {
           color: ${config.ar.home.theme.colors.text};
-          background: rgba(231, 130, 132, 0.8);
+          background: rgba(255, 123, 99, 0.8);
       }
     '';
   };

--- a/homeManagerModules/apps/wlogout/default.nix
+++ b/homeManagerModules/apps/wlogout/default.nix
@@ -7,6 +7,7 @@
   config = lib.mkIf config.ar.home.apps.wlogout.enable {
     programs.wlogout = {
       enable = true;
+
       layout = [
         {
           label = "logout";
@@ -27,35 +28,36 @@
           keybind = "r";
         }
       ];
+
       style = ''
         * {
           font-family: "${config.ar.home.theme.font.name}", sans-serif;
-        	background-image: none;
-        	box-shadow: none;
+          background-image: none;
+          box-shadow: none;
           transition: 20ms;
         }
 
         window {
-        	background-color: rgba(35, 38, 52, 0.8);
+          background-color: rgba(35, 38, 52, 0.8);
         }
 
         button {
-        	text-decoration-color: #FAFAFA;
-          color: #FAFAFA;
-        	background-color: ${config.ar.home.theme.colors.background};
-          background-color: rgba(12, 12, 12, 0.0);
-        	background-repeat: no-repeat;
-        	background-size: 10%;
+          margin: 5px;
           border-radius: 10;
+          border-color: ${config.ar.home.theme.colors.primary};
+          text-decoration-color: ${config.ar.home.theme.colors.text};
+          color: ${config.ar.home.theme.colors.text};
+          background-color: ${config.ar.home.theme.colors.background};
+          border-style: solid;
+          border-width: 2;
+          background-repeat: no-repeat;
+          background-position: center;
+          background-size: 25%;
         }
 
-        button:active, button:hover {
-        	background-color: ${config.ar.home.theme.colors.primary};
-        	outline-style: none;
-        }
-
-        #lock, #logout, #suspend, #hibernate, #shutdown, #reboot {
-          padding: 0;
+        button:focus, button:active, button:hover {
+          background-color: ${config.ar.home.theme.colors.primary};
+          outline-style: none;
         }
 
         #lock {

--- a/homeManagerModules/apps/wlogout/default.nix
+++ b/homeManagerModules/apps/wlogout/default.nix
@@ -31,9 +31,9 @@
 
       style = ''
         * {
-          font-family: "${config.ar.home.theme.font.name}", sans-serif;
           background-image: none;
           box-shadow: none;
+          font-family: "${config.ar.home.theme.font.name}", sans-serif;
           transition: 20ms;
         }
 
@@ -42,20 +42,20 @@
         }
 
         button {
-          margin: 5px;
-          border-radius: 10;
-          border-color: ${config.ar.home.theme.colors.primary};
-          text-decoration-color: ${config.ar.home.theme.colors.text};
-          color: ${config.ar.home.theme.colors.text};
           background-color: ${config.ar.home.theme.colors.background};
+          background-position: center;
+          background-repeat: no-repeat;
+          background-size: 25%;
+          border-color: ${config.ar.home.theme.colors.primary};
+          border-radius: 10;
           border-style: solid;
           border-width: 2;
-          background-repeat: no-repeat;
-          background-position: center;
-          background-size: 25%;
+          color: ${config.ar.home.theme.colors.text};
+          margin: 5px;
+          text-decoration-color: ${config.ar.home.theme.colors.text};
         }
 
-        button:focus, button:active, button:hover {
+        button:active, button:hover {
           background-color: ${config.ar.home.theme.colors.primary};
           outline-style: none;
         }

--- a/homeManagerModules/options.nix
+++ b/homeManagerModules/options.nix
@@ -364,13 +364,13 @@
 
         primary = lib.mkOption {
           description = "Primary color.";
-          default = "#78AEED";#"#CA9EE6";
+          default = "#78AEED"; #"#CA9EE6";
           type = lib.types.str;
         };
 
         secondary = lib.mkOption {
           description = "Secondary color.";
-          default = "#CA9EE6";#"#99D1DB";
+          default = "#CA9EE6"; #"#99D1DB";
           type = lib.types.str;
         };
 

--- a/homeManagerModules/options.nix
+++ b/homeManagerModules/options.nix
@@ -286,19 +286,19 @@
       cursorTheme = {
         name = lib.mkOption {
           description = "Cursor theme name.";
-          default = "catppuccin-frappe-dark-cursors";
+          default = "Bibata-Modern-Classic";
           type = lib.types.str;
         };
 
         size = lib.mkOption {
           description = "Cursor size.";
-          default = 24;
+          default = 20;
           type = lib.types.int;
         };
 
         package = lib.mkOption {
           description = "Cursor theme package.";
-          default = pkgs.catppuccin-cursors.frappeDark;
+          default = pkgs.bibata-cursors;
           type = lib.types.package;
         };
       };

--- a/homeManagerModules/options.nix
+++ b/homeManagerModules/options.nix
@@ -257,14 +257,14 @@
 
       qt = {
         name = lib.mkOption {
-          description = "Qt Kvantum theme name.";
-          default = "Catppuccin-Frappe-Mauve";
+          description = "Qt theme name.";
+          default = "Adwaita-Dark";
           type = lib.types.str;
         };
 
         package = lib.mkOption {
-          description = "Qt Kvantum theme package.";
-          default = pkgs.catppuccin-kvantum;
+          description = "Qt theme package.";
+          default = pkgs.adwaita-qt;
           type = lib.types.package;
         };
       };

--- a/homeManagerModules/options.nix
+++ b/homeManagerModules/options.nix
@@ -238,13 +238,13 @@
       gtk = {
         name = lib.mkOption {
           description = "GTK theme name.";
-          default = "catppuccin-frappe-mauve-compact+normal";
+          default = "adw-gtk3-dark";
           type = lib.types.str;
         };
 
         package = lib.mkOption {
           description = "GTK theme package.";
-          default = pkgs.catppuccin-gtk;
+          default = pkgs.adw-gtk3;
           type = lib.types.package;
         };
 
@@ -268,6 +268,7 @@
           type = lib.types.package;
         };
       };
+
       iconTheme = {
         name = lib.mkOption {
           description = "Icon theme name.";
@@ -277,7 +278,7 @@
 
         package = lib.mkOption {
           description = "Icon theme package.";
-          default = pkgs.catppuccin-papirus-folders;
+          default = pkgs.papirus-icon-theme;
           type = lib.types.package;
         };
       };
@@ -351,31 +352,31 @@
 
         text = lib.mkOption {
           description = "Text color.";
-          default = "#FAFAFA";
+          default = "#FFFFFF";
           type = lib.types.str;
         };
 
         background = lib.mkOption {
           description = "Background color.";
-          default = "#232634";
+          default = "#242424";
           type = lib.types.str;
         };
 
         primary = lib.mkOption {
           description = "Primary color.";
-          default = "#CA9EE6";
+          default = "#78AEED";#"#CA9EE6";
           type = lib.types.str;
         };
 
         secondary = lib.mkOption {
           description = "Secondary color.";
-          default = "#99D1DB";
+          default = "#CA9EE6";#"#99D1DB";
           type = lib.types.str;
         };
 
         inactive = lib.mkOption {
           description = "Inactive color.";
-          default = "#626880";
+          default = "#242424";
           type = lib.types.str;
         };
 

--- a/homeManagerModules/theme.nix
+++ b/homeManagerModules/theme.nix
@@ -62,35 +62,36 @@
 
       gtk4.extraConfig = lib.attrsets.optionalAttrs (config.ar.home.theme.colors.preferDark) {gtk-application-prefer-dark-theme = 1;};
 
-      # gtk3.extraCss =
-      #   if config.ar.home.theme.gtk.hideTitleBar
-      #   then ''
-      #     /* No (default) title bar on wayland */
-      #     headerbar.default-decoration {
-      #       /* You may need to tweak these values depending on your GTK theme */
-      #       margin-bottom: 50px;
-      #       margin-top: -100px;
-
-      #       background: transparent;
-      #       padding: 0;
-      #       border: 0;
-      #       min-height: 0;
-      #       font-size: 0;
-      #       box-shadow: none;
-      #     }
-
-      #     /* rm -rf window shadows */
-      #     window.csd,             /* gtk4? */
-      #     window.csd decoration { /* gtk3 */
-      #       box-shadow: none;
-      #     }
-      #   ''
-      #   else "/* */";
-
       gtk3.extraCss = ''
         @define-color accent_bg_color ${config.ar.home.theme.colors.primary};
+        @define-color accent_color @accent_bg_color;
 
-        @define-color accent_color @accent_bg_color; '';
+        ${
+          if config.ar.home.theme.gtk.hideTitleBar
+          then ''
+            /* No (default) title bar on wayland */
+            headerbar.default-decoration {
+              /* You may need to tweak these values depending on your GTK theme */
+              margin-bottom: 50px;
+              margin-top: -100px;
+
+              background: transparent;
+              padding: 0;
+              border: 0;
+              min-height: 0;
+              font-size: 0;
+              box-shadow: none;
+            }
+
+            /* rm -rf window shadows */
+            window.csd,             /* gtk4? */
+            window.csd decoration { /* gtk3 */
+              box-shadow: none;
+            }
+          ''
+          else "/* */"
+        }
+      '';
 
       gtk4.extraCss = config.gtk.gtk3.extraCss;
     };

--- a/homeManagerModules/theme.nix
+++ b/homeManagerModules/theme.nix
@@ -5,15 +5,20 @@
   ...
 }: {
   config = lib.mkIf config.ar.home.theme.enable {
-    home.pointerCursor = {
-      gtk.enable = true;
-      x11 = {
-        enable = true;
-        defaultCursor = config.ar.home.theme.cursorTheme.name;
+    home = {
+      packages = with pkgs; [gnome.adwaita-icon-theme];
+
+      pointerCursor = {
+        gtk.enable = true;
+        name = config.ar.home.theme.cursorTheme.name;
+        package = config.ar.home.theme.cursorTheme.package;
+        size = config.ar.home.theme.cursorTheme.size;
+
+        x11 = {
+          enable = true;
+          defaultCursor = config.ar.home.theme.cursorTheme.name;
+        };
       };
-      name = config.ar.home.theme.cursorTheme.name;
-      package = config.ar.home.theme.cursorTheme.package;
-      size = config.ar.home.theme.cursorTheme.size;
     };
 
     qt = {
@@ -61,30 +66,35 @@
 
       gtk4.extraConfig = lib.attrsets.optionalAttrs (config.ar.home.theme.colors.preferDark) {gtk-application-prefer-dark-theme = 1;};
 
-      gtk3.extraCss =
-        if config.ar.home.theme.gtk.hideTitleBar
-        then ''
-          /* No (default) title bar on wayland */
-          headerbar.default-decoration {
-            /* You may need to tweak these values depending on your GTK theme */
-            margin-bottom: 50px;
-            margin-top: -100px;
+      # gtk3.extraCss =
+      #   if config.ar.home.theme.gtk.hideTitleBar
+      #   then ''
+      #     /* No (default) title bar on wayland */
+      #     headerbar.default-decoration {
+      #       /* You may need to tweak these values depending on your GTK theme */
+      #       margin-bottom: 50px;
+      #       margin-top: -100px;
 
-            background: transparent;
-            padding: 0;
-            border: 0;
-            min-height: 0;
-            font-size: 0;
-            box-shadow: none;
-          }
+      #       background: transparent;
+      #       padding: 0;
+      #       border: 0;
+      #       min-height: 0;
+      #       font-size: 0;
+      #       box-shadow: none;
+      #     }
 
-          /* rm -rf window shadows */
-          window.csd,             /* gtk4? */
-          window.csd decoration { /* gtk3 */
-            box-shadow: none;
-          }
-        ''
-        else "/* */";
+      #     /* rm -rf window shadows */
+      #     window.csd,             /* gtk4? */
+      #     window.csd decoration { /* gtk3 */
+      #       box-shadow: none;
+      #     }
+      #   ''
+      #   else "/* */";
+
+      gtk3.extraCss = ''
+        @define-color accent_bg_color ${config.ar.home.theme.colors.primary};
+
+        @define-color accent_color @accent_bg_color; '';
 
       gtk4.extraCss = config.gtk.gtk3.extraCss;
     };

--- a/homeManagerModules/theme.nix
+++ b/homeManagerModules/theme.nix
@@ -24,13 +24,9 @@
     qt = {
       enable = true;
       platformTheme.name = "qtct";
-      style.name = "kvantum";
-    };
-
-    xdg.configFile = {
-      "Kvantum/${config.ar.home.theme.qt.name}".source = "${config.ar.home.theme.qt.package}/share/Kvantum/${config.ar.home.theme.qt.name}";
-      "Kvantum/kvantum.kvconfig".source = (pkgs.formats.ini {}).generate "kvantum.kvconfig" {
-        General.theme = config.ar.home.theme.qt.name;
+      style = {
+        package = config.ar.home.theme.qt.package;
+        name = config.ar.home.theme.qt.name;
       };
     };
 

--- a/homes/aly/default.nix
+++ b/homes/aly/default.nix
@@ -51,10 +51,7 @@
     apps = {
       alacritty.enable = true;
       bash.enable = true;
-      chromium = {
-        enable = true;
-        package = pkgs.brave;
-      };
+      chromium.enable = true;
       emacs.enable = true;
       fastfetch.enable = true;
       firefox.enable = true;
@@ -65,10 +62,7 @@
     };
 
     defaultApps.enable = true;
-
-    desktop = {
-      startupApps = [(lib.getExe' pkgs.keepassxc "keepassxc")];
-    };
+    desktop.startupApps = [(lib.getExe' pkgs.keepassxc "keepassxc")];
 
     theme = {
       enable = true;

--- a/homes/aly/firefox/default.nix
+++ b/homes/aly/firefox/default.nix
@@ -6,6 +6,18 @@
   self,
   ...
 }: {
+  home.file = let
+    recursive = false;
+    source = builtins.fetchGit {
+      url = "https://github.com/rafaelmardojai/firefox-gnome-theme.git";
+      rev = "8fb5267c5b3434f76983e29749aba7cd636e03ca";
+      ref = "master";
+    };
+  in {
+    ".mozilla/firefox/default/chrome" = {inherit recursive source;};
+    ".mozilla/firefox/work/chrome" = {inherit recursive source;};
+  };
+
   programs.firefox = {
     enable = true;
 
@@ -72,6 +84,7 @@
                 alias = "!bing";
               };
             };
+
             "Google" = {
               metaData = {
                 hidden = true;
@@ -92,6 +105,8 @@
           "privacy.trackingprotection.global-checkbox.enabled" = true;
           "privacy.trackingprotection.socialtracking.enabled" = true;
           "services.sync.prefs.sync.browser.uiCustomization.state" = true;
+          "svg.context-properties.content.enabled" = true;
+          "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
         };
       };
 
@@ -117,6 +132,8 @@
           "privacy.trackingprotection.global-checkbox.enabled" = true;
           "privacy.trackingprotection.socialtracking.enabled" = true;
           "signon.rememberSignons" = false;
+          "svg.context-properties.content.enabled" = true;
+          "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
         };
 
         id = 1;
@@ -131,6 +148,7 @@
                 alias = "!bing";
               };
             };
+
             "DuckDuckGo" = {
               metaData = {
                 hidden = true;
@@ -150,10 +168,8 @@
     icon = "firefox";
     mimeType = ["text/html" "text/xml"];
     name = "Firefox (work)";
+    settings = {StartupWMClass = "firework";};
     startupNotify = true;
     terminal = false;
-    settings = {
-      StartupWMClass = "firework";
-    };
   };
 }

--- a/homes/dustin/default.nix
+++ b/homes/dustin/default.nix
@@ -14,7 +14,6 @@
       fractal
       libreoffice-fresh
       plexamp
-      vlc
       webcord
       xfce.xfce4-taskmanager
       zoom-us
@@ -40,72 +39,10 @@
     };
 
     defaultApps.enable = true;
-
-    desktop = {
-      hyprland = {
-        randomWallpaper = true;
-      };
-    };
+    desktop.hyprland.randomWallpaper = true;
 
     theme = {
       enable = true;
-
-      gtk = {
-        name = "catppuccin-frappe-mauve-compact+normal";
-
-        package = pkgs.catppuccin-gtk.override {
-          accents = ["mauve"];
-          size = "compact";
-          variant = "frappe";
-          tweaks = ["normal"];
-        };
-      };
-
-      qt = {
-        name = "Catppuccin-Frappe-Mauve";
-
-        package = pkgs.catppuccin-kvantum.override {
-          accent = "Mauve";
-          variant = "Frappe";
-        };
-      };
-
-      iconTheme = {
-        name = "Papirus-Dark";
-
-        package = pkgs.catppuccin-papirus-folders.override {
-          flavor = "frappe";
-          accent = "mauve";
-        };
-      };
-
-      cursorTheme = {
-        name = "Catppuccin-Frappe-Dark-Cursors";
-        size = 24;
-        package = pkgs.catppuccin-cursors.frappeDark;
-      };
-
-      font = {
-        name = "NotoSans Nerd Font";
-        size = 11;
-        package = pkgs.nerdfonts.override {fonts = ["Noto"];};
-      };
-
-      terminalFont = {
-        name = "NotoSansM Nerd Font";
-        size = 11;
-        package = pkgs.nerdfonts.override {fonts = ["Noto"];};
-      };
-
-      colors = {
-        text = "#FAFAFA";
-        background = "#232634";
-        primary = "#CA9EE6";
-        secondary = "#99D1DB";
-        inactive = "#626880";
-        shadow = "#1A1A1A";
-      };
-
       wallpaper = "${config.xdg.dataHome}/backgrounds/jr-korpa-9XngoIpxcEo-unsplash.jpg";
     };
   };

--- a/homes/morgan/default.nix
+++ b/homes/morgan/default.nix
@@ -13,7 +13,6 @@
     packages = with pkgs; [
       fractal
       libreoffice-fresh
-      vlc
       webcord
       xfce.xfce4-taskmanager
     ];
@@ -41,63 +40,6 @@
 
     theme = {
       enable = true;
-
-      gtk = {
-        name = "catppuccin-frappe-mauve-compact+normal";
-
-        package = pkgs.catppuccin-gtk.override {
-          accents = ["mauve"];
-          size = "compact";
-          variant = "frappe";
-          tweaks = ["normal"];
-        };
-      };
-
-      qt = {
-        name = "Catppuccin-Frappe-Mauve";
-
-        package = pkgs.catppuccin-kvantum.override {
-          accent = "Mauve";
-          variant = "Frappe";
-        };
-      };
-
-      iconTheme = {
-        name = "Papirus-Dark";
-
-        package = pkgs.catppuccin-papirus-folders.override {
-          flavor = "frappe";
-          accent = "mauve";
-        };
-      };
-
-      cursorTheme = {
-        name = "Catppuccin-Frappe-Dark-Cursors";
-        size = 24;
-        package = pkgs.catppuccin-cursors.frappeDark;
-      };
-
-      font = {
-        name = "NotoSans Nerd Font";
-        size = 11;
-        package = pkgs.nerdfonts.override {fonts = ["Noto"];};
-      };
-
-      terminalFont = {
-        name = "NotoSansM Nerd Font";
-        size = 11;
-        package = pkgs.nerdfonts.override {fonts = ["Noto"];};
-      };
-
-      colors = {
-        text = "#FAFAFA";
-        background = "#232634";
-        primary = "#CA9EE6";
-        secondary = "#99D1DB";
-        inactive = "#626880";
-        shadow = "#1A1A1A";
-      };
-
       wallpaper = "${config.xdg.dataHome}/backgrounds/jr-korpa-9XngoIpxcEo-unsplash.jpg";
     };
   };

--- a/hosts/mauville/home.nix
+++ b/hosts/mauville/home.nix
@@ -8,13 +8,7 @@
   home-manager = {
     sharedModules = [
       {
-        programs.vscode.userSettings = {
-          "workbench.colorTheme" = lib.mkForce "Catppuccin Mocha";
-          "workbench.iconTheme" = lib.mkForce "catppuccin-mocha";
-        };
-
         xdg.userDirs.music = "/mnt/Media/Music";
-
         ar.home.desktop.hyprland.autoSuspend = false;
       }
     ];

--- a/hosts/mauville/home.nix
+++ b/hosts/mauville/home.nix
@@ -14,52 +14,8 @@
         };
 
         xdg.userDirs.music = "/mnt/Media/Music";
-        ar.home = {
-          desktop = {
-            hyprland.autoSuspend = false;
-            sway.autoSuspend = false;
-          };
-          theme = lib.mkForce {
-            enable = true;
-            gtk = {
-              name = "catppuccin-mocha-mauve-compact+normal";
-              package = pkgs.catppuccin-gtk.override {
-                accents = ["mauve"];
-                size = "compact";
-                variant = "mocha";
-                tweaks = ["normal"];
-              };
-            };
-            qt = {
-              name = "Catppuccin-Mocha-Mauve";
-              package = pkgs.catppuccin-kvantum.override {
-                accent = "Mauve";
-                variant = "Mocha";
-              };
-            };
-            iconTheme = {
-              name = "Papirus-Light";
-              package = pkgs.catppuccin-papirus-folders.override {
-                flavor = "mocha";
-                accent = "mauve";
-              };
-            };
-            cursorTheme = {
-              name = "catppuccin-mocha-dark-cursors";
-              size = 32;
-              package = pkgs.catppuccin-cursors.mochaDark;
-            };
-            colors = {
-              preferDark = true;
-              text = "#FAFAFA";
-              background = "#232634";
-              primary = "#CA9EE6";
-              secondary = "#99D1DB";
-              inactive = "#626880";
-              shadow = "#1A1A1A";
-            };
-          };
-        };
+        
+        ar.home.desktop.hyprland.autoSuspend = false;
       }
     ];
 

--- a/hosts/mauville/home.nix
+++ b/hosts/mauville/home.nix
@@ -14,7 +14,7 @@
         };
 
         xdg.userDirs.music = "/mnt/Media/Music";
-        
+
         ar.home.desktop.hyprland.autoSuspend = false;
       }
     ];

--- a/hosts/petalburg/home.nix
+++ b/hosts/petalburg/home.nix
@@ -8,12 +8,11 @@
   home-manager = {
     sharedModules = [
       {
-        ar.home.desktop.hyprland = {
-          tabletMode.enable = true;
-        };
         wayland.windowManager.hyprland.extraConfig = ''
           exec-once = ${lib.getExe inputs.iio-hyprland.packages.${pkgs.system}.default} "desc:Samsung Display Corp. 0x4152"
         '';
+
+        ar.home.desktop.hyprland.tabletMode.enable = true;
       }
     ];
   };

--- a/hosts/rustboro/home.nix
+++ b/hosts/rustboro/home.nix
@@ -17,7 +17,7 @@
             preset = "LoudnessEqualizer";
           };
           theme = {
-            cursorTheme.size = lib.mkForce 32;
+            cursorTheme.size = lib.mkForce 24;
             font.size = lib.mkForce 14;
             terminalFont.size = lib.mkForce 14;
           };

--- a/nixosModules/base/default.nix
+++ b/nixosModules/base/default.nix
@@ -14,28 +14,7 @@
   ];
 
   config = lib.mkIf config.ar.base.enable {
-    console = {
-      colors = [
-        "303446"
-        "e78284"
-        "a6d189"
-        "e5c890"
-        "8caaee"
-        "f4b8e4"
-        "81c8be"
-        "b5bfe2"
-        "626880"
-        "303446"
-        "e78284"
-        "a6d189"
-        "e5c890"
-        "8caaee"
-        "f4b8e4"
-        "81c8be"
-        "a5adce"
-      ];
-      useXkbConfig = true;
-    };
+    console.useXkbConfig = true;
 
     environment.systemPackages = with pkgs; [
       inputs.agenix.packages.${pkgs.system}.default

--- a/nixosModules/base/nixpkgs/default.nix
+++ b/nixosModules/base/nixpkgs/default.nix
@@ -20,42 +20,31 @@
         (final: prev: {
           audiobookshelf = unstable.audiobookshelf;
           brave = prev.brave.override {commandLineArgs = "--gtk-version=4 --enable-wayland-ime";};
-          catppuccin-gtk = prev.catppuccin-gtk.override {
-            accents = ["mauve"];
-            size = "compact";
-            variant = "frappe";
-            tweaks = ["normal"];
-          };
-          catppuccin-kvantum = prev.catppuccin-kvantum.override {
-            accent = "Mauve";
-            variant = "Frappe";
-          };
-          catppuccin-papirus-folders = prev.catppuccin-papirus-folders.override {
-            flavor = "frappe";
-            accent = "mauve";
-          };
-          catppuccin-plymouth = prev.catppuccin-plymouth.override {variant = "frappe";};
           google-chrome = prev.google-chrome.override {commandLineArgs = "--gtk-version=4 --enable-wayland-ime";};
           hyprland = inputs.hyprland.packages.${pkgs.system}.hyprland;
           hyprnome = unstable.hyprnome;
           hyprshot = unstable.hyprshot;
           intel-vaapi-driver = prev.intel-vaapi-driver.override {enableHybridCodec = true;};
           nerdfonts = prev.nerdfonts.override {fonts = ["DroidSansMono" "Noto"];};
+
           obsidian = prev.obsidian.overrideAttrs (old: {
             installPhase =
               builtins.replaceStrings ["--ozone-platform=wayland"]
               ["--ozone-platform=wayland --enable-wayland-ime"]
               old.installPhase;
           });
+
           sway = unstable.sway;
           swayfx = unstable.swayfx;
           vscodium = prev.vscodium.override {commandLineArgs = "--enable-wayland-ime";};
+
           webcord = prev.webcord.overrideAttrs (old: {
             installPhase =
               builtins.replaceStrings ["--ozone-platform-hint=auto"]
               ["--ozone-platform-hint=auto --enable-wayland-ime"]
               old.installPhase;
           });
+
           xdg-desktop-portal-hyprland = inputs.hyprland.packages.${pkgs.system}.xdg-desktop-portal-hyprland;
         })
       ];

--- a/nixosModules/base/plymouth/default.nix
+++ b/nixosModules/base/plymouth/default.nix
@@ -11,8 +11,6 @@
       initrd.verbose = false;
       plymouth = {
         enable = true;
-        themePackages = [pkgs.catppuccin-plymouth];
-        theme = "catppuccin-frappe";
         font = "${pkgs.nerdfonts}/share/fonts/truetype/NerdFonts/NotoSansNerdFont-Regular.ttf";
       };
     };

--- a/nixosModules/desktop/lightdm/default.nix
+++ b/nixosModules/desktop/lightdm/default.nix
@@ -16,13 +16,13 @@
       greeters.slick = {
         enable = true;
         theme = {
-          name = "catppuccin-frappe-mauve-compact+normal";
-          package = pkgs.catppuccin-gtk;
+          name = "adw-gtk3-dark";
+          package = pkgs.adw-gtk3;
         };
 
         iconTheme = {
           name = "Papirus-Dark";
-          package = pkgs.catppuccin-papirus-folders;
+          package = pkgs.papirus-icon-theme;
         };
 
         font = {
@@ -31,13 +31,13 @@
         };
 
         cursorTheme = {
-          name = "catppuccin-frappe-dark-cursors";
-          package = pkgs.catppuccin-cursors.frappeDark;
-          size = 24;
+          name = "Bibata-Modern-Classic";
+          package = pkgs.bibata-cursors;
+          size = 20;
         };
 
         extraConfig = ''
-          background=#303446
+          background=#242424
           enable-hidpi=on
         '';
       };

--- a/nixosModules/options.nix
+++ b/nixosModules/options.nix
@@ -180,7 +180,7 @@
       };
 
       hyprland.enable = lib.mkEnableOption "Hyprland wayland session.";
-      lightdm.enable = lib.mkEnableOption "Lightdm with Catppuccin theme.";
+      lightdm.enable = lib.mkEnableOption "Lightdm display manager.";
       plasma.enable = lib.mkEnableOption "Plasma desktop session.";
       steam.enable = lib.mkEnableOption "Steam + Gamescope session.";
       sway.enable = lib.mkEnableOption "Sway wayland session.";
@@ -227,7 +227,7 @@
       };
 
       plymouth.enable = lib.mkOption {
-        description = "Plymouth boot screen with catppuccin theme.";
+        description = "Plymouth boot screen.";
         default = config.ar.base.enable;
         type = lib.types.bool;
       };


### PR DESCRIPTION
It's a better, more consistent, more supported theme.

- [x] (home) change gtk theme
- [x] (home) change icon theme
- [x] (home) fix colors
- [x] (home) use Adwaita VSCodium theme
- [x] (home) use Adwaita QT theme
- [x] (home) fix wlogout css
- [x] (home) update neovim theme
- [x] (home) update emacs theme
- [x] (home) update cursor theme
- [x] (home) update chromium theme
- [x] (nixos) update lightdm theme
- [x] (nixos) update console colors
- [x] (nixos) update plymouth theme
- [x] (nixos) remove nixpkgs overlays
- [x] (home) remove host and user-specific overrides