### PR TITLE
switch on autoupgrade

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -318,11 +318,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720619751,
-        "narHash": "sha256-A6/7nXOW0UsrFu/IYqVmTMdkm5UjFJUDB4xpJvM5UvQ=",
+        "lastModified": 1720994659,
+        "narHash": "sha256-nN7sFe3tHG0xget7YYEErCx+kg4PqOnPAe8p8Pqg+ms=",
         "owner": "alyraffauf",
         "repo": "nixhw",
-        "rev": "5b22cdd5f53c88b98dc993c8d4578182aef8877f",
+        "rev": "d308ee6dfb9a46ab75b0e725b636f2c2846fc607",
         "type": "github"
       },
       "original": {

--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -165,7 +165,7 @@
     flake = "github:alyraffauf/nixcfg";
     operation = "switch";
     randomizedDelaySec = "20min";
-    
+
     rebootWindow = {
       lower = "02:00";
       upper = "06:00";

--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -161,13 +161,14 @@
   system.autoUpgrade = {
     enable = true;
     allowReboot = true;
-    dates = "01:00";
+    dates = "02:00";
     flake = "github:alyraffauf/nixcfg";
     operation = "switch";
-    randomizedDelaySec = "20min";
+    persistent = true;
+    randomizedDelaySec = "30min";
 
     rebootWindow = {
-      lower = "02:00";
+      lower = "04:00";
       upper = "06:00";
     };
   };

--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -164,7 +164,7 @@
     randomizedDelaySec = "20min";
     enable = true;
     flake = "github:alyraffauf/nixcfg";
-    operation = "boot";
+    operation = "switch";
     rebootWindow = {
       lower = "02:00";
       upper = "05:00";

--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -159,15 +159,16 @@
   };
 
   system.autoUpgrade = {
-    allowReboot = true;
-    dates = "04:00";
-    randomizedDelaySec = "20min";
     enable = true;
+    allowReboot = true;
+    dates = "01:00";
     flake = "github:alyraffauf/nixcfg";
     operation = "switch";
+    randomizedDelaySec = "20min";
+    
     rebootWindow = {
       lower = "02:00";
-      upper = "05:00";
+      upper = "06:00";
     };
   };
 


### PR DESCRIPTION
Current behavior is to build a new generation for the next boot daily. This moves to each host auto-switching to the new generation without reboot.