### PR TITLE
24.05 -> 24.11

### DIFF
--- a/common/base.nix
+++ b/common/base.nix
@@ -53,8 +53,6 @@
     '';
   };
 
-  sound.enable = true;
-
   zramSwap = {
     enable = lib.mkDefault true;
     memoryPercent = lib.mkDefault 50;

--- a/flake.lock
+++ b/flake.lock
@@ -57,22 +57,6 @@
         "type": "github"
       }
     },
-    "base16-foot": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696725948,
-        "narHash": "sha256-65bz2bUL/yzZ1c8/GQASnoiGwaF8DczlxJtzik1c0AU=",
-        "owner": "tinted-theming",
-        "repo": "base16-foot",
-        "rev": "eedbcfa30de0a4baa03e99f5e3ceb5535c2755ce",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "base16-foot",
-        "type": "github"
-      }
-    },
     "base16-helix": {
       "flake": false,
       "locked": {
@@ -89,50 +73,18 @@
         "type": "github"
       }
     },
-    "base16-kitty": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1665001328,
-        "narHash": "sha256-aRaizTYPpuWEcvoYE9U+YRX+Wsc8+iG0guQJbvxEdJY=",
-        "owner": "kdrag0n",
-        "repo": "base16-kitty",
-        "rev": "06bb401fa9a0ffb84365905ffbb959ae5bf40805",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kdrag0n",
-        "repo": "base16-kitty",
-        "type": "github"
-      }
-    },
-    "base16-tmux": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696725902,
-        "narHash": "sha256-wDPg5elZPcQpu7Df0lI5O8Jv4A3T6jUQIVg63KDU+3Q=",
-        "owner": "tinted-theming",
-        "repo": "base16-tmux",
-        "rev": "c02050bebb60dbb20cb433cd4d8ce668ecc11ba7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "base16-tmux",
-        "type": "github"
-      }
-    },
     "base16-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1663659192,
-        "narHash": "sha256-uJvaYYDMXvoo0fhBZUhN8WBXeJ87SRgof6GEK2efFT0=",
-        "owner": "chriskempson",
+        "lastModified": 1727042165,
+        "narHash": "sha256-52wtJGpVgB7UVsd6GL4jHapHZCP3MsMNdMNDCqfAGKU=",
+        "owner": "tinted-theming",
         "repo": "base16-vim",
-        "rev": "3be3cd82cd31acfcab9a41bad853d9c68d30478d",
+        "rev": "dfc1d89d56404cfd8e97f5d0dd1c8a7a019e68ce",
         "type": "github"
       },
       "original": {
-        "owner": "chriskempson",
+        "owner": "tinted-theming",
         "repo": "base16-vim",
         "type": "github"
       }
@@ -271,6 +223,27 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": [
+          "stylix",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "fromYaml": {
       "flake": false,
       "locked": {
@@ -354,16 +327,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1726989464,
-        "narHash": "sha256-Vl+WVTJwutXkimwGprnEtXc/s/s8sMuXzqXaspIGlwM=",
+        "lastModified": 1727383923,
+        "narHash": "sha256-4/vacp3CwdGoPf8U4e/N8OsGYtO09WTcQK5FqYfJbKs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f23fa308a7c067e52dfcc30a0758f47043ec176",
+        "rev": "ffe2d07e771580a005e675108212597e5b367d2d",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.05",
+        "ref": "master",
         "repo": "home-manager",
         "type": "github"
       }
@@ -439,16 +412,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727264057,
-        "narHash": "sha256-KQPI8CTTnB9CrJ7LrmLC4VWbKZfljEPBXOFGZFRpxao=",
+        "lastModified": 1727634051,
+        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "759537f06e6999e141588ff1c9be7f3a5c060106",
+        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -570,29 +543,31 @@
       "inputs": {
         "base16": "base16",
         "base16-fish": "base16-fish",
-        "base16-foot": "base16-foot",
         "base16-helix": "base16-helix",
-        "base16-kitty": "base16-kitty",
-        "base16-tmux": "base16-tmux",
         "base16-vim": "base16-vim",
         "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
         "gnome-shell": "gnome-shell",
         "home-manager": "home-manager_3",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems_4",
+        "tinted-foot": "tinted-foot",
+        "tinted-kitty": "tinted-kitty",
+        "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1718122552,
-        "narHash": "sha256-A+dBkSwp8ssHKV/WyXb9uqIYrHBqHvtSedU24Lq9lqw=",
+        "lastModified": 1727723275,
+        "narHash": "sha256-k4HrG8TJQ0RqDS1tlDz71kvWFBNQ7qZI9T5Z0qLR85Y=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e59d2c1725b237c362e4a62f5722f5b268d566c7",
+        "rev": "e7e97059776da7e34b739415a7bc8f80f606b803",
         "type": "github"
       },
       "original": {
         "owner": "danth",
-        "ref": "release-24.05",
+        "ref": "master",
         "repo": "stylix",
         "type": "github"
       }
@@ -639,6 +614,69 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "tinted-foot": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727574105,
+        "narHash": "sha256-ByMVgH0rZ1by2YIVJ47gE8/ZHWcG8yqsErQ4tKLbm7Q=",
+        "owner": "tinted-theming",
+        "repo": "tinted-foot",
+        "rev": "e558fe47e187093313f19fa6a9eea61940ffbd6b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "tinted-foot",
+        "type": "github"
+      }
+    },
+    "tinted-kitty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727426431,
+        "narHash": "sha256-tVtL8QqdVyU7JsLEYhR5aw+T6Ofu5xWiI0iEodUsbEI=",
+        "owner": "tinted-theming",
+        "repo": "tinted-kitty",
+        "rev": "09c2f8c4f7c0180c4888724e72f3a65e77679196",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "tinted-kitty",
+        "type": "github"
+      }
+    },
+    "tinted-tmux": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727571738,
+        "narHash": "sha256-AOITVZMhqELOzL5Jw54NIX7R8gFbTJqrHEDuPwgGYDQ=",
+        "owner": "tinted-theming",
+        "repo": "tinted-tmux",
+        "rev": "44fbe9034653c83a8ae68941aaeeeeb7503cd1ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "tinted-tmux",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727872461,
-        "narHash": "sha256-4Pw3fVhN6xey5+2gUBm9nQJAjBqivffr+a5ZsXYjzJ8=",
+        "lastModified": 1727977578,
+        "narHash": "sha256-DBORKcmQ7ZjA4qE1MsnF1MmZSokOGrw4W9vTCioOv2U=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "568727a884ae7cd9f266bd19aea655def8cafd78",
+        "rev": "574400001b3ffe555c7a21e0ff846230759be2ed",
         "type": "github"
       },
       "original": {
@@ -327,11 +327,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727817100,
-        "narHash": "sha256-dlyV9/eiWkm/Y/t2+k4CFZ29tBvCANmJogEYaHeAOTw=",
+        "lastModified": 1728041527,
+        "narHash": "sha256-03liqiJtk9UP7YQHW4r8MduKCK242FQzud8iWvvlK+o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "437ec62009fa8ceb684eb447d455ffba25911cf9",
+        "rev": "509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e",
         "type": "github"
       },
       "original": {
@@ -460,11 +460,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727898366,
-        "narHash": "sha256-8YJQ3ezwzdoZ37F+2WStJeAF5gZahqXPB19uTEVPiq4=",
+        "lastModified": 1728077937,
+        "narHash": "sha256-2SUHc7VoV6SBs0o9FXOom8g0/daVfkbKKQkx7/j/7no=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "400832822d42bdef1a193e424865c4f1b54dcbfa",
+        "rev": "f74e49cf480cc13f23fe79f476720c44e9bda1a2",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727531434,
-        "narHash": "sha256-b+GBgCWd2N6pkiTkRZaMFOPztPO4IVTaclYPrQl2uLk=",
+        "lastModified": 1727872461,
+        "narHash": "sha256-4Pw3fVhN6xey5+2gUBm9nQJAjBqivffr+a5ZsXYjzJ8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "b709e1cc33fcde71c7db43850a55ebe6449d0959",
+        "rev": "568727a884ae7cd9f266bd19aea655def8cafd78",
         "type": "github"
       },
       "original": {
@@ -327,11 +327,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727383923,
-        "narHash": "sha256-4/vacp3CwdGoPf8U4e/N8OsGYtO09WTcQK5FqYfJbKs=",
+        "lastModified": 1727817100,
+        "narHash": "sha256-dlyV9/eiWkm/Y/t2+k4CFZ29tBvCANmJogEYaHeAOTw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ffe2d07e771580a005e675108212597e5b367d2d",
+        "rev": "437ec62009fa8ceb684eb447d455ffba25911cf9",
         "type": "github"
       },
       "original": {
@@ -412,11 +412,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727634051,
-        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
+        "lastModified": 1727802920,
+        "narHash": "sha256-HP89HZOT0ReIbI7IJZJQoJgxvB2Tn28V6XS3MNKnfLs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
+        "rev": "27e30d177e57d912d614c88c622dcfdb2e6e6515",
         "type": "github"
       },
       "original": {
@@ -444,11 +444,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1727634051,
-        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
+        "lastModified": 1727802920,
+        "narHash": "sha256-HP89HZOT0ReIbI7IJZJQoJgxvB2Tn28V6XS3MNKnfLs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
+        "rev": "27e30d177e57d912d614c88c622dcfdb2e6e6515",
         "type": "github"
       },
       "original": {
@@ -460,11 +460,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727795932,
-        "narHash": "sha256-qfHikL1eQ5C7n5n+vk6bE0T3QjxcoGO20ePgKfpsVCc=",
+        "lastModified": 1727898366,
+        "narHash": "sha256-8YJQ3ezwzdoZ37F+2WStJeAF5gZahqXPB19uTEVPiq4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6df3e5a1ccb28201bbd6a4f3d9bf03343ca0b720",
+        "rev": "400832822d42bdef1a193e424865c4f1b54dcbfa",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -60,11 +60,11 @@
     "base16-helix": {
       "flake": false,
       "locked": {
-        "lastModified": 1696727917,
-        "narHash": "sha256-FVrbPk+NtMra0jtlC5oxyNchbm8FosmvXIatkRbYy1g=",
+        "lastModified": 1725860795,
+        "narHash": "sha256-Z2o8VBPW3I+KKTSfe25kskz0EUj7MpUh8u355Z1nVsU=",
         "owner": "tinted-theming",
         "repo": "base16-helix",
-        "rev": "dbe1480d99fe80f08df7970e471fac24c05f2ddb",
+        "rev": "7f795bf75d38e0eea9fed287264067ca187b88a9",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
     "base16-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1727042165,
-        "narHash": "sha256-52wtJGpVgB7UVsd6GL4jHapHZCP3MsMNdMNDCqfAGKU=",
+        "lastModified": 1716150083,
+        "narHash": "sha256-ZMhnNmw34ogE5rJZrjRv5MtG3WaqKd60ds2VXvT6hEc=",
         "owner": "tinted-theming",
         "repo": "base16-vim",
-        "rev": "dfc1d89d56404cfd8e97f5d0dd1c8a7a019e68ce",
+        "rev": "6e955d704d046b0dc3e5c2d68a2a6eeffd2b5d3d",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727359191,
-        "narHash": "sha256-5PltTychnExFwzpEnY3WhOywaMV/M6NxYI/y3oXuUtw=",
+        "lastModified": 1727531434,
+        "narHash": "sha256-b+GBgCWd2N6pkiTkRZaMFOPztPO4IVTaclYPrQl2uLk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "67dc29be3036cc888f0b9d4f0a788ee0f6768700",
+        "rev": "b709e1cc33fcde71c7db43850a55ebe6449d0959",
         "type": "github"
       },
       "original": {
@@ -231,11 +231,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -349,11 +349,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714981474,
-        "narHash": "sha256-b3/U21CJjCjJKmA9WqUbZGZgCvospO3ArOUTgJugkOY=",
+        "lastModified": 1724435763,
+        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6ebe7be2e67be7b9b54d61ce5704f6fb466c536f",
+        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
         "type": "github"
       },
       "original": {
@@ -370,11 +370,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1721829827,
-        "narHash": "sha256-9tB29tP3ZQ2tU2c+FrWrGqSm70ZrJP8H9WZKzHx55zI=",
+        "lastModified": 1727632156,
+        "narHash": "sha256-gfH/jcrmI27OEge8OGPe7JpC0jrQJuX7v9hM/ObjjW8=",
         "owner": "JeanSchoeller",
         "repo": "iio-hyprland",
-        "rev": "bbf59e10cbf293e64b765864a324e971fcc06125",
+        "rev": "bd6be6b7e0fbc8ca1a5ccbf536602838e52c347e",
         "type": "github"
       },
       "original": {
@@ -444,11 +444,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1727122398,
-        "narHash": "sha256-o8VBeCWHBxGd4kVMceIayf5GApqTavJbTa44Xcg5Rrk=",
+        "lastModified": 1727634051,
+        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "30439d93eb8b19861ccbe3e581abf97bdc91b093",
+        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
         "type": "github"
       },
       "original": {
@@ -460,11 +460,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727413844,
-        "narHash": "sha256-Oue4ulh0EeTOSDVZkhJk4oRav2I3MoROqDJpzLfivh8=",
+        "lastModified": 1727795932,
+        "narHash": "sha256-qfHikL1eQ5C7n5n+vk6bE0T3QjxcoGO20ePgKfpsVCc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "29e6d9d93fca1f1093a432c21104c72a8d044fee",
+        "rev": "6df3e5a1ccb28201bbd6a4f3d9bf03343ca0b720",
         "type": "github"
       },
       "original": {
@@ -635,11 +635,11 @@
     "tinted-foot": {
       "flake": false,
       "locked": {
-        "lastModified": 1727574105,
-        "narHash": "sha256-ByMVgH0rZ1by2YIVJ47gE8/ZHWcG8yqsErQ4tKLbm7Q=",
+        "lastModified": 1696725948,
+        "narHash": "sha256-65bz2bUL/yzZ1c8/GQASnoiGwaF8DczlxJtzik1c0AU=",
         "owner": "tinted-theming",
         "repo": "tinted-foot",
-        "rev": "e558fe47e187093313f19fa6a9eea61940ffbd6b",
+        "rev": "eedbcfa30de0a4baa03e99f5e3ceb5535c2755ce",
         "type": "github"
       },
       "original": {
@@ -651,11 +651,11 @@
     "tinted-kitty": {
       "flake": false,
       "locked": {
-        "lastModified": 1727426431,
-        "narHash": "sha256-tVtL8QqdVyU7JsLEYhR5aw+T6Ofu5xWiI0iEodUsbEI=",
+        "lastModified": 1665001328,
+        "narHash": "sha256-aRaizTYPpuWEcvoYE9U+YRX+Wsc8+iG0guQJbvxEdJY=",
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "09c2f8c4f7c0180c4888724e72f3a65e77679196",
+        "rev": "06bb401fa9a0ffb84365905ffbb959ae5bf40805",
         "type": "github"
       },
       "original": {
@@ -667,11 +667,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1727571738,
-        "narHash": "sha256-AOITVZMhqELOzL5Jw54NIX7R8gFbTJqrHEDuPwgGYDQ=",
+        "lastModified": 1696725902,
+        "narHash": "sha256-wDPg5elZPcQpu7Df0lI5O8Jv4A3T6jUQIVg63KDU+3Q=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "44fbe9034653c83a8ae68941aaeeeeb7503cd1ae",
+        "rev": "c02050bebb60dbb20cb433cd4d8ce668ecc11ba7",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
     "wallpapers": {
       "flake": false,
       "locked": {
-        "lastModified": 1727132619,
-        "narHash": "sha256-1V9LK/0GwsLjAwedYcW5uXq1y8l4W86Ce2DvrlseLcA=",
+        "lastModified": 1727677872,
+        "narHash": "sha256-p68hYur7luTI48jJuwjpAaKcXC+Rs/LZhjCJkthauCs=",
         "owner": "alyraffauf",
         "repo": "wallpapers",
-        "rev": "b86110d079361e785014fdc22eb3684bccf891c9",
+        "rev": "1f3c34d936b02fd02c975e0aa99527afb423badc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Aly's NixOS flake.";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 
     agenix = {
@@ -17,7 +17,7 @@
 
     home-manager = {
       inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:nix-community/home-manager/release-24.05";
+      url = "github:nix-community/home-manager/master";
     };
 
     iio-hyprland = {
@@ -34,7 +34,7 @@
 
     stylix = {
       inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:danth/stylix/release-24.05";
+      url = "github:danth/stylix/master";
     };
 
     wallpapers = {

--- a/homeManagerModules/apps/nemo/default.nix
+++ b/homeManagerModules/apps/nemo/default.nix
@@ -5,7 +5,7 @@
   ...
 }: {
   config = lib.mkIf config.ar.home.apps.nemo.enable {
-    home.packages = [pkgs.cinnamon.nemo];
+    home.packages = [pkgs.nemo];
 
     dconf = {
       enable = true;

--- a/homeManagerModules/defaultApps.nix
+++ b/homeManagerModules/defaultApps.nix
@@ -25,7 +25,7 @@ in {
         terminal
         terminalEditor
         videoPlayer
-        webBrowser
+        # webBrowser
       ];
 
       sessionVariables = {

--- a/homeManagerModules/desktop/wayland/default.nix
+++ b/homeManagerModules/desktop/wayland/default.nix
@@ -23,7 +23,7 @@
 
     home.packages = with pkgs; [
       blueberry
-      gnome.file-roller
+      file-roller
       libnotify
       networkmanagerapplet
     ];

--- a/homeManagerModules/options.nix
+++ b/homeManagerModules/options.nix
@@ -38,7 +38,7 @@ in {
 
       nemo.enable = lib.mkOption {
         description = "Cinnamon Nemo file manager.";
-        default = cfg.defaultApps.fileManager == pkgs.cinnamon.nemo;
+        default = cfg.defaultApps.fileManager == pkgs.nemo;
         type = lib.types.bool;
       };
 
@@ -79,8 +79,8 @@ in {
       enable = lib.mkEnableOption "Declaratively set default apps and file associations.";
       audioPlayer = lib.mkPackageOption pkgs "audio player" {default = ["celluloid"];};
       editor = lib.mkPackageOption pkgs "text editor" {default = ["vscodium"];};
-      fileManager = lib.mkPackageOption pkgs "file manager" {default = ["cinnamon" "nemo"];};
-      imageViewer = lib.mkPackageOption pkgs "image viewer" {default = ["gnome" "eog"];};
+      fileManager = lib.mkPackageOption pkgs "file manager" {default = ["nemo"];};
+      imageViewer = lib.mkPackageOption pkgs "image viewer" {default = ["eog"];};
       pdfViewer = lib.mkPackageOption pkgs "pdf viewer" {default = ["evince"];};
       terminal = lib.mkPackageOption pkgs "terminal emulator" {default = ["kitty"];};
       terminalEditor = lib.mkPackageOption pkgs "terminal text editor" {default = ["vim"];};

--- a/homeManagerModules/theme.nix
+++ b/homeManagerModules/theme.nix
@@ -8,7 +8,7 @@
 in {
   config = lib.mkIf cfg.theme.enable {
     home.packages = [
-      pkgs.gnome.adwaita-icon-theme
+      pkgs.adwaita-icon-theme
       pkgs.liberation_ttf
     ];
 

--- a/homes/aly/default.nix
+++ b/homes/aly/default.nix
@@ -58,7 +58,7 @@ self: {pkgs, ...}: {
     };
   };
 
-  systemd.user.startServices = "legacy"; # Needed for auto-mounting agenix secrets.
+  systemd.user.startServices = true; # Needed for auto-mounting agenix secrets.
 
   ar.home = {
     apps = {

--- a/hosts/lavaridge/default.nix
+++ b/hosts/lavaridge/default.nix
@@ -36,7 +36,11 @@
     };
   };
 
-  environment.variables.GDK_SCALE = "2";
+  environment.variables = {
+    FLAKE = lib.mkForce "github:alyraffauf/nixcfg/upgrade-to-2411";
+    GDK_SCALE = "2";
+  };
+
   networking.hostName = "lavaridge";
   programs.firefox.policies.Preferences."media.ffmpeg.vaapi.enabled" = lib.mkForce false;
   system.stateVersion = "24.05";

--- a/hosts/lavaridge/default.nix
+++ b/hosts/lavaridge/default.nix
@@ -42,7 +42,6 @@
   };
 
   networking.hostName = "lavaridge";
-  programs.firefox.policies.Preferences."media.ffmpeg.vaapi.enabled" = lib.mkForce false;
   system.stateVersion = "24.05";
 
   ar = {

--- a/hosts/mauville/default.nix
+++ b/hosts/mauville/default.nix
@@ -52,19 +52,19 @@ in {
     samba = {
       enable = true;
       openFirewall = true;
-      securityType = "user";
 
-      # extraConfig = ''
-      #   read raw = Yes
-      #   write raw = Yes
-      #   socket options = TCP_NODELAY IPTOS_LOWDELAY SO_RCVBUF=131072 SO_SNDBUF=131072
-      #   min receivefile size = 16384
-      #   use sendfile = true
-      #   aio read size = 16384
-      #   aio write size = 16384
-      # '';
+      settings = {
+        global = {
+          security = "user";
+          "read raw" = "Yes";
+          "write raw" = "Yes";
+          "socket options" = "TCP_NODELAY IPTOS_LOWDELAY SO_RCVBUF=131072 SO_SNDBUF=131072";
+          "min receivefile size" = 16384;
+          "use sendfile" = true;
+          "aio read size" = 16384;
+          "aio write size" = 16384;
+        };
 
-      shares = {
         Media = {
           "create mask" = "0755";
           "directory mask" = "0755";

--- a/hosts/mauville/default.nix
+++ b/hosts/mauville/default.nix
@@ -54,15 +54,15 @@ in {
       openFirewall = true;
       securityType = "user";
 
-      extraConfig = ''
-        read raw = Yes
-        write raw = Yes
-        socket options = TCP_NODELAY IPTOS_LOWDELAY SO_RCVBUF=131072 SO_SNDBUF=131072
-        min receivefile size = 16384
-        use sendfile = true
-        aio read size = 16384
-        aio write size = 16384
-      '';
+      # extraConfig = ''
+      #   read raw = Yes
+      #   write raw = Yes
+      #   socket options = TCP_NODELAY IPTOS_LOWDELAY SO_RCVBUF=131072 SO_SNDBUF=131072
+      #   min receivefile size = 16384
+      #   use sendfile = true
+      #   aio read size = 16384
+      #   aio write size = 16384
+      # '';
 
       shares = {
         Media = {

--- a/hosts/slateport/raffauflabs.nix
+++ b/hosts/slateport/raffauflabs.nix
@@ -31,7 +31,7 @@ in {
       passwordFile = config.age.secrets.cloudflare.path;
       protocol = "cloudflare";
       ssl = true;
-      use = "web, web=dynamicdns.park-your-domain.com/getip, web-skip='Current IP Address: '";
+      usev4 = "web, web=dynamicdns.park-your-domain.com/getip, web-skip='Current IP Address: '";
       username = "token";
       zone = domain;
     };

--- a/hwModules/common/gpu/amd/default.nix
+++ b/hwModules/common/gpu/amd/default.nix
@@ -1,14 +1,18 @@
 {...}: {
   environment.variables.VDPAU_DRIVER = "radeonsi";
 
-  hardware.amdgpu = {
-    initrd.enable = true;
+  hardware = {
+    amdgpu = {
+      initrd.enable = true;
 
-    amdvlk = {
-      enable = true;
-      support32Bit.enable = true;
+      amdvlk = {
+        enable = true;
+        support32Bit.enable = true;
+      };
+
+      opencl.enable = true;
     };
 
-    opencl.enable = true;
+    graphics.enable = true;
   };
 }

--- a/hwModules/common/gpu/intel/default.nix
+++ b/hwModules/common/gpu/intel/default.nix
@@ -11,8 +11,6 @@
 
     opengl = {
       enable = true;
-      driSupport = true;
-      driSupport32Bit = true;
 
       extraPackages = [
         pkgs.intel-media-driver # LIBVA_DRIVER_NAME=iHD

--- a/hwModules/common/gpu/intel/default.nix
+++ b/hwModules/common/gpu/intel/default.nix
@@ -9,7 +9,7 @@
   hardware = {
     intel-gpu-tools.enable = true;
 
-    opengl = {
+    graphics = {
       enable = true;
 
       extraPackages = [

--- a/nixosModules/services/flatpak/default.nix
+++ b/nixosModules/services/flatpak/default.nix
@@ -5,7 +5,7 @@
   ...
 }: {
   config = lib.mkIf config.ar.services.flatpak.enable {
-    environment.systemPackages = with pkgs; [gnome.gnome-software];
+    environment.systemPackages = with pkgs; [gnome-software];
 
     fileSystems = let
       mkRoSymBind = path: {
@@ -18,8 +18,8 @@
         name = "system-icons";
         paths =
           (with pkgs; [
-            gnome.adwaita-icon-theme
-            gnome.gnome-themes-extra
+            adwaita-icon-theme
+            gnome-themes-extra
           ])
           ++ lib.optional (config.stylix.enable) config.stylix.cursor.package;
 


### PR DESCRIPTION
Upgrades us from 24.05->24.11. The goal here is to migrate any breaking changes or deprecations ahead of nixpkgs branch off, so we don't have to delay moving over.

TODO:

- [x] Migrate to master in anticipation of breaking changes.
- [x] Migrate package renames.
- [x] Migrate samba settings.
- [x] Remove breaking configuration changes in nixpkgs.
- [ ] Verify hardware configurations.
- [ ] Lock to upstream branched releases when available.
- [ ] Fix firefox collisions causing build errors cf. https://github.com/nix-community/home-manager/issues/5675 

Host/Hardware Verifications:

- [x] lavaridge
- [x] petalburg
- [ ] fallarbor
- [ ] mauville
- [ ] rustboro
- [ ] slateport
