### PR TITLE
hwModules: integrate legion go improvements

### DIFF
--- a/common/base.nix
+++ b/common/base.nix
@@ -1,7 +1,5 @@
 {lib, ...}: {
   boot.loader.systemd-boot.configurationLimit = lib.mkDefault 10;
-  console.useXkbConfig = true;
-  hardware.keyboard.qmk.enable = true;
   environment.variables.FLAKE = lib.mkDefault "github:alyraffauf/nixcfg";
 
   programs = {
@@ -36,26 +34,10 @@
       };
     };
 
-    logind = {
-      powerKey = "suspend";
-      powerKeyLongPress = "poweroff";
-    };
-
     openssh = {
       enable = true;
       openFirewall = true;
       settings.PasswordAuthentication = false;
     };
-
-    udev.extraRules = ''
-      # Disable Fn Lock for ThinkPad Trackpoint USB/Bluetooth Keyboard
-      SUBSYSTEM=="hid", DRIVER=="lenovo", ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="6047|60ee", ATTR{fn_lock}="0"
-      SUBSYSTEM=="input", ATTRS{id/vendor}=="17ef", ATTRS{id/product}=="6048|60e1", TEST=="/sys/$devpath/device/fn_lock", RUN+="/bin/sh -c 'echo 0 > \"/sys/$devpath/device/fn_lock\"'"
-    '';
-  };
-
-  zramSwap = {
-    enable = lib.mkDefault true;
-    memoryPercent = lib.mkDefault 50;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -146,9 +146,11 @@
       common-tailscale = import ./common/tailscale.nix;
       common-wifi-profiles = import ./common/wifi.nix;
 
+      hw-common = import ./hwModules/common;
       hw-common-amd-cpu = import ./hwModules/common/gpu/amd;
       hw-common-amd-gpu = import ./hwModules/common/cpu/amd;
       hw-common-bluetooth = import ./hwModules/common/bluetooth;
+      hw-common-gaming = import ./hwModules/common/gaming;
       hw-common-intel-cpu = import ./hwModules/common/cpu/intel;
       hw-common-intel-gpu = import ./hwModules/common/gpu/intel;
       hw-common-laptop = import ./hwModules/common/laptop;

--- a/hosts/mauville/default.nix
+++ b/hosts/mauville/default.nix
@@ -21,10 +21,12 @@ in {
     self.nixosModules.common-pkgs
     self.nixosModules.common-tailscale
     self.nixosModules.common-wifi-profiles
+    self.nixosModules.hw-common
     self.nixosModules.hw-common-amd-cpu
     self.nixosModules.hw-common-amd-gpu
     self.nixosModules.hw-common-bluetooth
     self.nixosModules.hw-common-ssd
+    self.nixosModules.hw-common-gaming
   ];
 
   boot = {
@@ -44,7 +46,6 @@ in {
     };
   };
 
-  hardware.enableAllFirmware = true;
   networking.hostName = "mauville";
 
   services = {

--- a/hosts/slateport/default.nix
+++ b/hosts/slateport/default.nix
@@ -16,6 +16,7 @@
     self.nixosModules.common-pkgs
     self.nixosModules.common-tailscale
     self.nixosModules.common-wifi-profiles
+    self.nixosModules.hw-common
     self.nixosModules.hw-common-bluetooth
     self.nixosModules.hw-common-intel-cpu
     self.nixosModules.hw-common-intel-gpu
@@ -31,7 +32,6 @@
     };
   };
 
-  hardware.enableAllFirmware = true;
   networking.hostName = "slateport";
 
   services = {

--- a/hwModules/common/cpu/amd/default.nix
+++ b/hwModules/common/cpu/amd/default.nix
@@ -1,5 +1,19 @@
-{lib, ...}: {
-  boot.kernelModules = ["kvm-amd"];
+# Best for Ryzen CPUs
+{
+  config,
+  lib,
+  ...
+}: {
+  boot = {
+    blacklistedKernelModules = ["k10temp"]; # Conflicts with zenpower
+    extraModulePackages = with config.boot.kernelPackages; [zenpower];
+
+    kernelModules = [
+      "kvm-amd"
+      "zenpower" # Improved temperature monitoring
+    ];
+  };
+
   hardware.cpu.amd.updateMicrocode = true;
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
 }

--- a/hwModules/common/default.nix
+++ b/hwModules/common/default.nix
@@ -1,0 +1,26 @@
+{lib, ...}: {
+  console.useXkbConfig = true;
+
+  hardware = {
+    enableAllFirmware = true;
+    keyboard.qmk.enable = true;
+  };
+
+  services = {
+    logind = {
+      powerKey = "suspend";
+      powerKeyLongPress = "poweroff";
+    };
+
+    udev.extraRules = ''
+      # Disable Fn Lock for ThinkPad Trackpoint USB/Bluetooth Keyboard
+      SUBSYSTEM=="hid", DRIVER=="lenovo", ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="6047|60ee", ATTR{fn_lock}="0"
+      SUBSYSTEM=="input", ATTRS{id/vendor}=="17ef", ATTRS{id/product}=="6048|60e1", TEST=="/sys/$devpath/device/fn_lock", RUN+="/bin/sh -c 'echo 0 > \"/sys/$devpath/device/fn_lock\"'"
+    '';
+  };
+
+  zramSwap = {
+    enable = lib.mkDefault true;
+    memoryPercent = lib.mkDefault 50;
+  };
+}

--- a/hwModules/common/gaming/default.nix
+++ b/hwModules/common/gaming/default.nix
@@ -1,0 +1,42 @@
+{lib, ...}: {
+  boot.kernel.sysctl = {
+    # Improved file monitoring
+    "fs.inotify.max_user_instances" = 8192;
+    "fs.inotify.max_user_watches" = 524288;
+
+    # Disable watchdogs for maximum performance at the cost of resiliency
+    "kernel.nmi_watchdog" = 0;
+    "kernel.soft_watchdog" = 0;
+    "kernel.split_lock_mitigate" = 0;
+    "kernel.watchdog" = 0;
+
+    # Network optimizations
+    "net.core.default_qdisc" = "fq";
+    "net.ipv4.tcp_congestion_control" = "bbr";
+    "net.ipv4.tcp_mtu_probing" = lib.mkForce 1;
+
+    # Memory management
+    "vm.dirty_background_bytes" = 134217728;
+    "vm.dirty_bytes" = 268435456;
+    "vm.max_map_count" = lib.mkForce 2147483642;
+    "vm.page-cluster" = 0;
+    "vm.swappiness" = 180;
+    "vm.watermark_boost_factor" = 0;
+    "vm.watermark_scale_factor" = 125;
+  };
+
+  services.udev.extraRules = ''
+    # Significantly improved I/O performance
+    ## SSD
+    ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="kyber"
+
+    ## NVME
+    ACTION=="add|change", KERNEL=="nvme[0-9]n[0-9]", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="kyber"
+
+    ## MicroSD
+    ACTION=="add|change", KERNEL=="mmcblk[0-9]p[0-9]", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="bfq"
+
+    ## HDD
+    ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="1", ATTR{queue/scheduler}="bfq"
+  '';
+}

--- a/hwModules/framework/13/amd-7000/default.nix
+++ b/hwModules/framework/13/amd-7000/default.nix
@@ -16,15 +16,20 @@
 
   boot = {
     initrd.availableKernelModules = ["nvme" "sd_mod" "thunderbolt" "usb_storage" "xhci_pci"];
+
     extraModprobeConfig = ''
       options snd_hda_intel power_save=1
     '';
+
     kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
   };
 
   networking.networkmanager = {
     enable = true;
-    wifi.powersave = true;
-    wifi.backend = "iwd";
+
+    wifi = {
+      backend = "iwd";
+      powersave = true;
+    };
   };
 }

--- a/hwModules/framework/13/amd-7000/default.nix
+++ b/hwModules/framework/13/amd-7000/default.nix
@@ -7,6 +7,7 @@
   imports = [
     ../../common.nix
     ../common.nix
+    self.nixosModules.hw-common
     self.nixosModules.hw-common-amd-cpu
     self.nixosModules.hw-common-amd-gpu
     self.nixosModules.hw-common-bluetooth

--- a/hwModules/framework/13/intel-11th/default.nix
+++ b/hwModules/framework/13/intel-11th/default.nix
@@ -7,6 +7,7 @@
   imports = [
     ../../common.nix
     ../common.nix
+    self.nixosModules.hw-common
     self.nixosModules.hw-common-bluetooth
     self.nixosModules.hw-common-intel-cpu
     self.nixosModules.hw-common-intel-gpu

--- a/hwModules/framework/common.nix
+++ b/hwModules/framework/common.nix
@@ -18,10 +18,7 @@
 
   environment.systemPackages = [pkgs.framework-tool] ++ lib.optional (pkgs ? "fw-ectool") pkgs.fw-ectool;
 
-  hardware = {
-    enableAllFirmware = true;
-    sensor.iio.enable = true;
-  };
+  hardware.sensor.iio.enable = true;
 
   services = {
     fprintd.enable = true;

--- a/hwModules/lenovo/legion/go/default.nix
+++ b/hwModules/lenovo/legion/go/default.nix
@@ -22,24 +22,18 @@ in {
   ];
 
   boot = {
-    initrd = {
-      availableKernelModules = [
-        "amdgpu"
-        "nvme"
-        "rtsx_pci_sdmmc"
-        "sd_mod"
-        "sdhci_pci"
-        "thunderbolt"
-        "usb_storage"
-        "usbhid"
-        "xhci_pci"
-      ];
+    initrd.availableKernelModules = [
+      "nvme"
+      "rtsx_pci_sdmmc"
+      "sd_mod"
+      "sdhci_pci"
+      "thunderbolt"
+      "usb_storage"
+      "usbhid"
+      "xhci_pci"
+    ];
 
-      kernelModules = ["amdgpu"];
-    };
-
-    blacklistedKernelModules = ["k10temp"]; # Conflicts with zenpower
-    extraModulePackages = with config.boot.kernelPackages; [acpi_call zenpower];
+    extraModulePackages = with config.boot.kernelPackages; [acpi_call];
 
     kernel.sysctl = {
       # Improved file monitoring
@@ -66,8 +60,6 @@ in {
       "vm.watermark_boost_factor" = 0;
       "vm.watermark_scale_factor" = 125;
     };
-
-    kernelModules = ["zenpower"]; # Improved temperature monitoring
 
     # Xanmod seems more responsive under load
     kernelPackages = lib.mkDefault pkgs.linuxPackages_xanmod_latest;

--- a/hwModules/lenovo/legion/go/default.nix
+++ b/hwModules/lenovo/legion/go/default.nix
@@ -44,6 +44,8 @@ in {
   hardware.sensor.iio.enable = true;
 
   services = {
+    logind.killUserProcesses = true;
+
     pipewire.wireplumber.configPackages = [
       (pkgs.writeTextDir "share/pipewire/pipewire.conf.d/10-legion-go-convolver.conf" ''
         # Convolver Configuration for Pipewire

--- a/hwModules/thinkpad/common.nix
+++ b/hwModules/thinkpad/common.nix
@@ -1,10 +1,6 @@
 {...}: {
-  hardware = {
-    enableAllFirmware = true;
-
-    trackpoint = {
-      enable = true;
-      emulateWheel = true;
-    };
+  hardware.trackpoint = {
+    enable = true;
+    emulateWheel = true;
   };
 }

--- a/hwModules/thinkpad/t440p/default.nix
+++ b/hwModules/thinkpad/t440p/default.nix
@@ -1,6 +1,7 @@
 {self, ...}: {
   imports = [
     ../common.nix
+    self.nixosModules.hw-common
     self.nixosModules.hw-common-bluetooth
     self.nixosModules.hw-common-intel-cpu
     self.nixosModules.hw-common-intel-gpu


### PR DESCRIPTION
Integrates lessons learned from setting up the Legion Go with other hardware modules, and creates a common module with misc config relevant to all hosts + gaming module for gaming optimizations.